### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `docker.io/paketobuildpacks/jprofiler`
-The Paketo JProfiler Buildpack is a Cloud Native Buildpack that contributes the JProfiler agent and configures it to connect to the service.
+The Paketo Buildpack for JProfiler is a Cloud Native Buildpack that contributes the JProfiler agent and configures it to connect to the service.
 
 ## Behavior
 This buildpack will participate if all the following conditions are met

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/jprofiler"
   id = "paketo-buildpacks/jprofiler"
   keywords = ["jprofiler", "agent", "profiler", "java"]
-  name = "Paketo JProfiler Buildpack"
+  name = "Paketo Buildpack for JProfiler"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo JProfiler Buildpack' to 'Paketo Buildpack for JProfiler'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
