### PR TITLE
Add ARM64 Support

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -2,6 +2,9 @@ github:
   username: ${{ secrets.JAVA_GITHUB_USERNAME }}
   token:    ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
+helpers:
+  "bin/helper": "$GOMOD/cmd/helper"
+
 codeowners:
 - path:  "*"
   owner: "@paketo-buildpacks/app-monitoring-maintainers"

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -25,7 +25,7 @@ jobs:
                 username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.22"
             - name: Install create-package
               run: |
                 #!/usr/bin/env bash
@@ -33,13 +33,24 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/create-package@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+            - uses: buildpacks/github-actions/setup-tools@v5.6.0
               with:
-                crane-version: 0.19.0
+                crane-version: 0.19.1
                 yj-version: 5.1.0
-            - uses: buildpacks/github-actions/setup-pack@v5.5.3
-              with:
-                pack-version: 0.33.2
+            - name: Install pack
+              run: |
+                #!/usr/bin/env bash
+                # this is coming from a copy of https://github.com/buildpacks/pack/actions/runs/8118576298 stored on box
+                # TODO to revisit when the official one is out
+                set -euo pipefail
+
+                echo "Installing pack experimental"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl -L "https://ent.box.com/shared/static/j4d1bfe9uk1sb0i7zjvci0md9xmy41u4" -o ${HOME}/bin/pack
+                chmod +x "${HOME}"/bin/pack
             - name: Enable pack Experimental
               if: ${{ false }}
               run: |
@@ -106,21 +117,23 @@ jobs:
 
                 if [[ "${INCLUDE_DEPENDENCIES}" == "true" ]]; then
                   create-package \
-                    --source ${SOURCE_PATH:-.} \
+                    --source "${SOURCE_PATH:-.}" \
                     --cache-location "${HOME}"/carton-cache \
                     --destination "${HOME}"/buildpack \
                     --include-dependencies \
                     --version "${VERSION}"
                 else
                   create-package \
-                    --source ${SOURCE_PATH:-.} \
+                    --source "${SOURCE_PATH:-.}" \
                     --destination "${HOME}"/buildpack \
                     --version "${VERSION}"
                 fi
 
-                PACKAGE_FILE=${SOURCE_PATH:-.}/package.toml
-                [[ -e ${PACKAGE_FILE} ]] && cp ${PACKAGE_FILE} "${HOME}"/package.toml
-                printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}"/buildpack "${OS}" >> "${HOME}"/package.toml
+                PACKAGE_FILE="${SOURCE_PATH:-.}/package.toml"
+                if [ -f "${PACKAGE_FILE}" ]; then
+                  cp "${PACKAGE_FILE}" "${HOME}/buildpack/package.toml"
+                  printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}/buildpack" "${OS}" >> "${HOME}/buildpack/package.toml"
+                fi
               env:
                 INCLUDE_DEPENDENCIES: "false"
                 OS: linux
@@ -133,15 +146,23 @@ jobs:
 
                 set -euo pipefail
 
+                COMPILED_BUILDPACK="${HOME}/buildpack"
+
+                # create-package puts the buildpack here, we need to run from that directory
+                #   for component buildpacks so that pack doesn't need a package.toml
+                cd "${COMPILED_BUILDPACK}"
+                CONFIG=""
+                if [ -f "${COMPILED_BUILDPACK}/package.toml" ]; then
+                  CONFIG="--config ${COMPILED_BUILDPACK}/package.toml"
+                fi
 
                 PACKAGE_LIST=($PACKAGES)
                 # Extract first repo (Docker Hub) as the main to package & register
                 PACKAGE=${PACKAGE_LIST[0]}
 
                 if [[ "${PUBLISH:-x}" == "true" ]]; then
-                  pack buildpack package \
-                    "${PACKAGE}:${VERSION}" \
-                    --config "${HOME}"/package.toml \
+                  pack -v buildpack package \
+                    "${PACKAGE}:${VERSION}" ${CONFIG} \
                     --publish
 
                   if [[ -n ${VERSION_MINOR:-} && -n ${VERSION_MAJOR:-} ]]; then
@@ -165,10 +186,9 @@ jobs:
                     done
 
                 else
-                  pack buildpack package \
-                    "${PACKAGE}:${VERSION}" \
-                    --config "${HOME}"/package.toml \
-                    --format "${FORMAT}"
+                  pack -v buildpack package \
+                    "${PACKAGE}:${VERSION}" ${CONFIG} \
+                    --format "${FORMAT}" $([ -n "$TTL_SH_PUBLISH" ] && [ "$TTL_SH_PUBLISH" = "true" ] && echo "--publish")
                 fi
               env:
                 PACKAGES: docker.io/paketobuildpacks/jprofiler gcr.io/paketo-buildpacks/jprofiler
@@ -199,7 +219,7 @@ jobs:
                 DIGEST: ${{ steps.package.outputs.digest }}
                 GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - if: ${{ true }}
-              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1
+              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.6.0
               with:
                 address: docker.io/paketobuildpacks/jprofiler@${{ steps.package.outputs.digest }}
                 id: paketo-buildpacks/jprofiler

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -17,7 +17,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.22"
             - name: Install create-package
               run: |
                 #!/usr/bin/env bash
@@ -25,9 +25,20 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/create-package@latest
-            - uses: buildpacks/github-actions/setup-pack@v5.5.3
-              with:
-                pack-version: 0.33.2
+            - name: Install pack
+              run: |
+                #!/usr/bin/env bash
+                # this is coming from a copy of https://github.com/buildpacks/pack/actions/runs/8118576298 stored on box
+                # TODO to revisit when the official one is out
+                set -euo pipefail
+
+                echo "Installing pack experimental"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl -L "https://ent.box.com/shared/static/j4d1bfe9uk1sb0i7zjvci0md9xmy41u4" -o ${HOME}/bin/pack
+                chmod +x "${HOME}"/bin/pack
             - name: Enable pack Experimental
               if: ${{ false }}
               run: |
@@ -93,21 +104,23 @@ jobs:
 
                 if [[ "${INCLUDE_DEPENDENCIES}" == "true" ]]; then
                   create-package \
-                    --source ${SOURCE_PATH:-.} \
+                    --source "${SOURCE_PATH:-.}" \
                     --cache-location "${HOME}"/carton-cache \
                     --destination "${HOME}"/buildpack \
                     --include-dependencies \
                     --version "${VERSION}"
                 else
                   create-package \
-                    --source ${SOURCE_PATH:-.} \
+                    --source "${SOURCE_PATH:-.}" \
                     --destination "${HOME}"/buildpack \
                     --version "${VERSION}"
                 fi
 
-                PACKAGE_FILE=${SOURCE_PATH:-.}/package.toml
-                [[ -e ${PACKAGE_FILE} ]] && cp ${PACKAGE_FILE} "${HOME}"/package.toml
-                printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}"/buildpack "${OS}" >> "${HOME}"/package.toml
+                PACKAGE_FILE="${SOURCE_PATH:-.}/package.toml"
+                if [ -f "${PACKAGE_FILE}" ]; then
+                  cp "${PACKAGE_FILE}" "${HOME}/buildpack/package.toml"
+                  printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}/buildpack" "${OS}" >> "${HOME}/buildpack/package.toml"
+                fi
               env:
                 INCLUDE_DEPENDENCIES: "true"
                 OS: linux
@@ -118,15 +131,23 @@ jobs:
 
                 set -euo pipefail
 
+                COMPILED_BUILDPACK="${HOME}/buildpack"
+
+                # create-package puts the buildpack here, we need to run from that directory
+                #   for component buildpacks so that pack doesn't need a package.toml
+                cd "${COMPILED_BUILDPACK}"
+                CONFIG=""
+                if [ -f "${COMPILED_BUILDPACK}/package.toml" ]; then
+                  CONFIG="--config ${COMPILED_BUILDPACK}/package.toml"
+                fi
 
                 PACKAGE_LIST=($PACKAGES)
                 # Extract first repo (Docker Hub) as the main to package & register
                 PACKAGE=${PACKAGE_LIST[0]}
 
                 if [[ "${PUBLISH:-x}" == "true" ]]; then
-                  pack buildpack package \
-                    "${PACKAGE}:${VERSION}" \
-                    --config "${HOME}"/package.toml \
+                  pack -v buildpack package \
+                    "${PACKAGE}:${VERSION}" ${CONFIG} \
                     --publish
 
                   if [[ -n ${VERSION_MINOR:-} && -n ${VERSION_MAJOR:-} ]]; then
@@ -150,14 +171,14 @@ jobs:
                     done
 
                 else
-                  pack buildpack package \
-                    "${PACKAGE}:${VERSION}" \
-                    --config "${HOME}"/package.toml \
-                    --format "${FORMAT}"
+                  pack -v buildpack package \
+                    "${PACKAGE}:${VERSION}" ${CONFIG} \
+                    --format "${FORMAT}" $([ -n "$TTL_SH_PUBLISH" ] && [ "$TTL_SH_PUBLISH" = "true" ] && echo "--publish")
                 fi
               env:
                 FORMAT: image
                 PACKAGES: test
+                TTL_SH_PUBLISH: "false"
                 VERSION: ${{ steps.version.outputs.version }}
     unit:
         name: Unit Test
@@ -172,7 +193,7 @@ jobs:
                 restore-keys: ${{ runner.os }}-go-
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.22"
             - name: Install richgo
               run: |
                 #!/usr/bin/env bash

--- a/.github/workflows/pb-update-go.yml
+++ b/.github/workflows/pb-update-go.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.22"
             - uses: actions/checkout@v4
             - name: Update Go Version & Modules
               id: update-go
@@ -49,7 +49,7 @@ jobs:
                 echo "commit-body=${COMMIT_BODY}" >> "$GITHUB_OUTPUT"
                 echo "commit-semver=${COMMIT_SEMVER}" >> "$GITHUB_OUTPUT"
               env:
-                GO_VERSION: "1.20"
+                GO_VERSION: "1.22"
             - uses: peter-evans/create-pull-request@v6
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>

--- a/.github/workflows/pb-update-jprofiler.yml
+++ b/.github/workflows/pb-update-jprofiler.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.22"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,9 +19,9 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+            - uses: buildpacks/github-actions/setup-tools@v5.6.0
               with:
-                crane-version: 0.19.0
+                crane-version: 0.19.1
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency

--- a/.github/workflows/pb-update-pipeline.yml
+++ b/.github/workflows/pb-update-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.22"
             - name: Install octo
               run: |
                 #!/usr/bin/env bash
@@ -55,6 +55,12 @@ jobs:
                 )
 
                 git add .github/
+                git add .gitignore
+
+                if [ -f scripts/build.sh ]; then
+                  git add scripts/build.sh
+                fi
+
                 git checkout -- .
 
                 echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 the original author or authors.
+# Copyright 2018-2020 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 bin/
+linux/
 dependencies/
 package/
 scratch/
+

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 the original author or authors.
+# Copyright 2018-2024 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,9 +57,9 @@ api = "0.7"
     cpes = ["cpe:2.3:a:jprofiler:agent:14.0.3:*:*:*:*:*:*:*"]
     id = "jprofiler"
     name = "JProfiler Agent"
-    purl = "pkg:generic/jprofiler-agent@14.0.3?arch=amd64"
+    purl = "pkg:generic/jprofiler-agent@14.0.3"
     sha256 = "60a878023e5b77b13b7e545a0abaed5cb2a8111374c0f56032a26fb0b2acee05"
-    stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
+    stacks = ["*"]
     uri = "https://download-gcdn.ej-technologies.com/jprofiler/jprofiler_linux_14_0_3.tar.gz"
     version = "14.0.3"
 
@@ -67,10 +67,12 @@ api = "0.7"
       uri = "https://www.ej-technologies.com/buy/jprofiler/licensing.html"
 
 [[stacks]]
-  id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
-  id = "io.paketo.stacks.tiny"
-
-[[stacks]]
   id = "*"
+
+[[targets]]
+  arch = "amd64"
+  os = "linux"
+
+[[targets]]
+  arch = "arm64"
+  os = "linux"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,7 +28,7 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/jprofiler/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "NOTICE", "README.md", "jprofiler.png", "bin/build", "bin/detect", "bin/helper", "bin/main", "buildpack.toml"]
+  include-files = ["LICENSE", "NOTICE", "README.md", "linux/amd64/bin/build", "linux/amd64/bin/detect", "linux/amd64/bin/main", "linux/amd64/bin/helper", "linux/arm64/bin/build", "linux/arm64/bin/detect", "linux/arm64/bin/main", "linux/arm64/bin/helper", "buildpack.toml"]
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]

--- a/jprofiler/build_test.go
+++ b/jprofiler/build_test.go
@@ -34,6 +34,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		ctx libcnb.BuildContext
 	)
 
+	it.Before(func() {
+		t.Setenv("BP_ARCH", "amd64")
+	})
+
 	it("contributes Java agent API <= 0.6", func() {
 		ctx.Buildpack.Metadata = map[string]interface{}{
 			"dependencies": []map[string]interface{}{

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
-GOOS="linux" go build -ldflags='-s -w' -o bin/helper github.com/paketo-buildpacks/jprofiler/v4/cmd/helper
-GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/paketo-buildpacks/jprofiler/v4/cmd/main
+GOMOD=$(head -1 go.mod | awk '{print $2}')
+GOOS="linux" GOARCH="amd64" go build -ldflags='-s -w' -o "linux/amd64/bin/helper" "$GOMOD/cmd/helper"
+GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o "linux/arm64/bin/helper" "$GOMOD/cmd/helper"
+GOOS="linux" GOARCH="amd64" go build -ldflags='-s -w' -o linux/amd64/bin/main "$GOMOD/cmd/main"
+GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o linux/arm64/bin/main "$GOMOD/cmd/main"
 
 if [ "${STRIP:-false}" != "false" ]; then
-  strip bin/helper bin/main
+  strip linux/amd64/bin/helper linux/arm64/bin/helper
+  strip linux/amd64/bin/main linux/arm64/bin/main
 fi
 
-if [ "${COMPRESS:-false}" != "false" ]; then
-  upx -q -9 bin/helper bin/main
+if [ "${COMPRESS:-none}" != "none" ]; then
+  $COMPRESS linux/amd64/bin/helper linux/arm64/bin/helper
+  $COMPRESS linux/amd64/bin/main linux/arm64/bin/main
 fi
 
-ln -fs main bin/build
-ln -fs main bin/detect
+ln -fs main linux/amd64/bin/build
+ln -fs main linux/arm64/bin/build
+ln -fs main linux/amd64/bin/detect
+ln -fs main linux/arm64/bin/detect


### PR DESCRIPTION
## Summary

ARM64 Support

I tested this with the paketo-samples/java/maven sample app. When building, it installs the same agent because it supports multiple architectures but we do need to set an env variable to point the agent to the right helper shared library (based on arch). When running, you can see it's picking the right architecture and starting successfully.

```
> docker run -it -e BPL_JPROFILER_ENABLED=true apps/maven
Calculating JVM memory based on 7377712K available memory
For more information on this calculation, see https://paketo.io/docs/reference/java-reference/#memory-calculator
Calculated JVM Memory Configuration: -XX:MaxDirectMemorySize=10M -Xmx6977226K -XX:MaxMetaspaceSize=93285K -XX:ReservedCodeCacheSize=240M -Xss1M (Total Memory: 7377712K, Thread Count: 50, Loaded Class Count: 14056, Headroom: 0%)
Enabling Java Native Memory Tracking
Adding 137 container CA certificates to JVM truststore
Spring Cloud Bindings Enabled
JProfiler enabled on port 8849
Picked up JAVA_TOOL_OPTIONS: -Djava.security.properties=/layers/paketo-buildpacks_bellsoft-liberica/java-security-properties/java-security.properties -XX:+ExitOnOutOfMemoryError -XX:MaxDirectMemorySize=10M -Xmx6977226K -XX:MaxMetaspaceSize=93285K -XX:ReservedCodeCacheSize=240M -Xss1M -XX:+UnlockDiagnosticVMOptions -XX:NativeMemoryTracking=summary -XX:+PrintNMTStatistics -Dorg.springframework.cloud.bindings.boot.enable=true -agentpath:/layers/paketo-buildpacks_jprofiler/jprofiler/bin/linux-aarch64/libjprofilerti.so=port=8849,nowait
JProfiler> Protocol version 66
JProfiler> Java 21 detected.
JProfiler> Don't wait for frontend to connect.
JProfiler> 64-bit library
JProfiler> Starting up without initial configuration.
JProfiler> Listening locally on port: 8849.
JProfiler> Enabling native methods instrumentation.
JProfiler> Can retransform classes.
JProfiler> Can retransform any class.
JProfiler> Native library initialized
JProfiler> VM initialized
JProfiler> Retransforming 7 base class files.
JProfiler> Base classes instrumented.
  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::            (v3.3.0-RC1)

2024-06-07T20:28:45.816Z  INFO 1 --- [           main] io.paketo.demo.DemoApplication           : Starting DemoApplication v0.0.1-SNAPSHOT using Java 21.0.3 with PID 1 (/workspace/BOOT-INF/classes started by cnb in /workspace)
2024-06-07T20:28:45.824Z  INFO 1 --- [           main] io.paketo.demo.DemoApplication           : No active profile set, falling back to 1 default profile: "default"
2024-06-07T20:28:46.657Z  INFO 1 --- [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
2024-06-07T20:28:46.891Z  INFO 1 --- [           main] o.s.b.web.embedded.netty.NettyWebServer  : Netty started on port 8080 (http)
2024-06-07T20:28:46.901Z  INFO 1 --- [           main] io.paketo.demo.DemoApplication           : Started DemoApplication in 1.37 seconds (process running for 1.755)
```