### PR TITLE
Fix BPL_JPROFILER_ENABLED BP_JPROFILER_ENABLED, now reading it as pro…

### DIFF
--- a/helper/properties.go
+++ b/helper/properties.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/paketo-buildpacks/libpak/sherpa"
 )
 
 type Properties struct {
@@ -30,7 +31,8 @@ type Properties struct {
 }
 
 func (p Properties) Execute() (map[string]string, error) {
-	if _, ok := os.LookupEnv("BPL_JPROFILER_ENABLED"); !ok {
+
+	if isEnabled := sherpa.ResolveBool("BPL_JPROFILER_ENABLED"); !isEnabled {
 		return nil, nil
 	}
 

--- a/helper/properties_test.go
+++ b/helper/properties_test.go
@@ -37,9 +37,15 @@ func testProperties(t *testing.T, context spec.G, it spec.S) {
 		Expect(p.Execute()).To(BeNil())
 	})
 
+	it("returns nil if $BPL_JPROFILER_ENABLED is false", func() {
+		Expect(os.Setenv("BPL_JPROFILER_ENABLED", "false")).To(Succeed())
+		Expect(p.Execute()).To(BeNil())
+		Expect(os.Unsetenv("BPL_JPROFILER_ENABLED")).To(Succeed())
+	})
+
 	context("$BPL_JPROFILER_ENABLED", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BPL_JPROFILER_ENABLED", "")).To(Succeed())
+			Expect(os.Setenv("BPL_JPROFILER_ENABLED", "true")).To(Succeed())
 		})
 
 		it.After(func() {

--- a/jprofiler/detect.go
+++ b/jprofiler/detect.go
@@ -31,7 +31,7 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 		return libcnb.DetectResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
 	}
 
-	if _, ok := cr.Resolve("BP_JPROFILER_ENABLED"); !ok {
+	if isEnabled := cr.ResolveBool("BP_JPROFILER_ENABLED"); !isEnabled {
 		return libcnb.DetectResult{Pass: false}, nil
 	}
 

--- a/jprofiler/detect_test.go
+++ b/jprofiler/detect_test.go
@@ -39,6 +39,11 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{Pass: false}))
 	})
 
+	it("fails with BP_JPROFILER_ENABLED set to false", func() {
+		Expect(os.Setenv("BP_JPROFILER_ENABLED", "false")).To(Succeed())
+		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{Pass: false}))
+	})
+
 	context("$BP_JPROFILER_ENABLED", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_JPROFILER_ENABLED", "true")).To(Succeed())


### PR DESCRIPTION
…per bool

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Env vars `BPL_JPROFILER_ENABLED` and `BP_JPROFILER_ENABLED` weren't read as proper booleans.

Fixes #120 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
